### PR TITLE
Add passing test for comparing null to objects

### DIFF
--- a/modules/__tests__/index-test.js
+++ b/modules/__tests__/index-test.js
@@ -13,6 +13,13 @@ describe('undefined and null', () => {
       expect(serialEqual(undefined, null)).toBe(false)
     })
   })
+
+  describe('when one is null and the other is an object', () => {
+    it('returns false', () => {
+      expect(serialEqual({}, null)).toBe(false)
+      expect(serialEqual(null, {})).toBe(false)
+    })
+  })
 })
 
 describe('string primitives', () => {


### PR DESCRIPTION
This was passing already, but I thought an explicit test would be
helpful to prevent https://github.com/mjackson/history/issues/378 from
regressing.
